### PR TITLE
err is not defined, using caught e instead?

### DIFF
--- a/transport.js
+++ b/transport.js
@@ -224,7 +224,7 @@ module.exports = function( options ) {
         })
       }
       catch(e) {
-        handle_error(err,res);
+        handle_error(e,res);
       }
     })
 


### PR DESCRIPTION
{ [Error]
  seneca: 'ReferenceError: err is not defined\n    at Object.handle (/media/chen/misc/code/seneca/node_modules/seneca/node_modules/seneca-transport/transport.js:227:22)\n
