### PR TITLE
Fix broken client example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,9 @@ And talk to it:
 
 ```JavaScript
 require('seneca')()
-  .listen()
-  .ready(function(){
-    this.act('foo:1,bar:A',function(err,out){console.log(out)})
-    this.act('foo:2,bar:B',function(err,out){console.log(out)})
-  })
+    .client()
+    .act('foo:1,bar:A',function(err,out){console.log(out)})
+    .act('foo:2,bar:B',function(err,out){console.log(out)})
 ```
 
 And this prints:


### PR DESCRIPTION
Client code doesn't run as shown. 

Client code snippet uses .listen(), which fails when run as a separate process because the service process is already listening to the localhost:10101 default endpoint.
